### PR TITLE
fixed comments not loading on proposals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'country_select', "~> 3.1", require: 'country_select_without_sort_alphabetic
 gem 'language_list'
 gem 'therubyracer'
 gem 'execjs'
-
+gem 'graphql', '~> 1.12.13'
 gem 'sprockets', '< 4.0'
 
 gem 'rack', '>= 2.0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,7 +391,7 @@ GEM
     graphiql-rails (1.4.11)
       railties
       sprockets-rails
-    graphql (1.13.13)
+    graphql (1.12.24)
     hashdiff (1.0.1)
     hashie (5.0.0)
     htmlentities (4.3.4)
@@ -705,6 +705,7 @@ DEPENDENCIES
   execjs
   faker
   figaro
+  graphql (~> 1.12.13)
   kaminari (~> 1.2.1)
   language_list
   letter_opener_web (~> 1.3.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,9 +78,9 @@ Rails.application.configure do
   # deployments.
   revision = File.read(Rails.root/"REVISION").chomp rescue "63b178c"
 
-  memcached_servers = ENV.fetch('MEMCACHED_SERVERS'){ "10.0.1.5:11211" }.split
+  # memcached_servers = ENV.fetch('MEMCACHED_SERVERS'){ "10.0.1.5:11211" }.split
   concurrency       = ENV.fetch('NUM_THREADS'){ 5 }
-  config.cache_store = :mem_cache_store, *memcached_servers, { namespace: "#{instance_name}:#{revision}:default", pool_size: concurrency }
+  # config.cache_store = :mem_cache_store, *memcached_servers, { namespace: "#{instance_name}:#{revision}:default", pool_size: concurrency }
 
 
   # Use a real queuing backend for Active Job (and separate queues per environment)


### PR DESCRIPTION
Comment section was disabled for proposals which had a "comments enabled" setting. While loading proposal pages, the traceback looked like this:

```
 Completed 500 Internal Server Error in 17ms (ActiveRecord: 1.7ms)
   
 ArgumentError (wrong number of arguments (given 3, expected 2)):
   
 graphql (1.13.13) lib/graphql/schema.rb:505:in `get_field'
 graphql (1.13.13) lib/graphql/schema/warden.rb:139:in `block (2 levels) in get_field'
 graphql (1.13.13) lib/graphql/schema/warden.rb:329:in `block in read_through'
 graphql (1.13.13) lib/graphql/schema/warden.rb:148:in `get_field'
 /home/decidim/.rbenv/versions/2.6.6/lib/ruby/2.6.0/forwardable.rb:230:in `get_field'
 graphql (1.13.13) lib/graphql/static_validation/rules/fields_will_merge.rb:343:in `block in find_fields_and_fragments'
 graphql (1.13.13) lib/graphql/static_validation/rules/fields_will_merge.rb:340:in `each'
 graphql (1.13.13) lib/graphql/static_validation/rules/fields_will_merge.rb:340:in `find_fields_and_fragments'
 graphql (1.13.13) lib/graphql/static_validation/rules/fields_will_merge.rb:333:in `fields_and_fragments_from_selection'
 graphql (1.13.13) lib/graphql/static_validation/rules/fields_will_merge.rb:61:in `conflicts_within_selection_set'
 graphql (1.13.13) lib/graphql/static_validation/rules/fields_will_merge.rb:25:in `block in on_operation_definition'
 graphql (1.13.13) lib/graphql/static_validation/rules/fields_will_merge.rb:52:in `setting_errors'
 graphql (1.13.13) lib/graphql/static_validation/rules/fields_will_merge.rb:25:in `on_operation_definition'
 graphql (1.13.13) lib/graphql/static_validation/rules/operation_names_are_valid.rb:12:in `on_operation_definition'
 graphql (1.13.13) lib/graphql/static_validation/rules/unique_directives_per_location.rb:27:in `block (2 levels) in <module:UniqueDirectivesPerLocation>'
 graphql (1.13.13) lib/graphql/internal_representation/rewrite.rb:68:in `block in on_operation_definition'
 graphql (1.13.13) lib/graphql/internal_representation/rewrite.rb:92:in `push_root_node'
 graphql (1.13.13) lib/graphql/internal_representation/rewrite.rb:68:in `on_operation_definition'
 graphql (1.13.13) lib/graphql/static_validation/base_visitor.rb:76:in `on_operation_definition'
 graphql (1.13.13) lib/graphql/language/visitor.rb:79:in `public_send'
 graphql (1.13.13) lib/graphql/language/visitor.rb:79:in `visit_node'
 graphql (1.13.13) lib/graphql/language/visitor.rb:174:in `on_node_with_modifications'
 graphql (1.13.13) lib/graphql/language/visitor.rb:102:in `block in on_abstract_node'
 graphql (1.13.13) lib/graphql/language/visitor.rb:101:in `each'
 graphql (1.13.13) lib/graphql/language/visitor.rb:101:in `on_abstract_node'
 graphql (1.13.13) lib/graphql/language/visitor.rb:123:in `on_document'
 graphql (1.13.13) lib/graphql/static_validation/definition_dependencies.rb:38:in `on_document'
 graphql (1.13.13) lib/graphql/static_validation/rules/variables_are_used_and_defined.rb:79:in `on_document'
 graphql (1.13.13) lib/graphql/static_validation/rules/fragment_spreads_are_possible.rb:26:in `on_document'
 graphql (1.13.13) lib/graphql/static_validation/rules/fragments_are_used.rb:6:in `on_document'
 graphql (1.13.13) lib/graphql/static_validation/rules/fragments_are_finite.rb:6:in `on_document'
 graphql (1.13.13) lib/graphql/static_validation/rules/fragment_names_are_unique.rb:17:in `on_document'
 graphql (1.13.13) lib/graphql/static_validation/rules/operation_names_are_valid.rb:16:in `on_document'
 graphql (1.13.13) lib/graphql/static_validation/rules/no_definitions_are_present.rb:34:in `on_document'
 graphql (1.13.13) lib/graphql/language/visitor.rb:79:in `public_send'
 graphql (1.13.13) lib/graphql/language/visitor.rb:79:in `visit_node'
 graphql (1.13.13) lib/graphql/language/visitor.rb:174:in `on_node_with_modifications'
 graphql (1.13.13) lib/graphql/language/visitor.rb:68:in `visit'
 graphql (1.13.13) lib/graphql/static_validation/validator.rb:57:in `block (3 levels) in validate'
 graphql (1.13.13) lib/graphql/static_validation/validator.rb:44:in `catch'
 graphql (1.13.13) lib/graphql/static_validation/validator.rb:44:in `block (2 levels) in validate'
 /home/decidim/.rbenv/versions/2.6.6/lib/ruby/2.6.0/timeout.rb:76:in `timeout'
 graphql (1.13.13) lib/graphql/static_validation/validator.rb:43:in `block in validate'
 graphql (1.13.13) lib/graphql/tracing.rb:67:in `trace'
 graphql (1.13.13) lib/graphql/static_validation/validator.rb:30:in `validate'
 graphql (1.13.13) lib/graphql/query/validation_pipeline.rb:75:in `ensure_has_validated'
 graphql (1.13.13) lib/graphql/query/validation_pipeline.rb:35:in `valid?'
 graphql (1.13.13) lib/graphql/query.rb:316:in `valid?'
 graphql (1.13.13) lib/graphql/analysis/analyze_query.rb:16:in `block (2 levels) in analyze_multiplex'
 graphql (1.13.13) lib/graphql/analysis/analyze_query.rb:15:in `map'
 graphql (1.13.13) lib/graphql/analysis/analyze_query.rb:15:in `block in analyze_multiplex'
 graphql (1.13.13) lib/graphql/tracing.rb:67:in `trace'
 graphql (1.13.13) lib/graphql/analysis/analyze_query.rb:13:in `analyze_multiplex'
 graphql (1.13.13) lib/graphql/execution/multiplex.rb:210:in `block in instrument_and_analyze'
 graphql (1.13.13) lib/graphql/execution/instrumentation.rb:29:in `block (2 levels) in apply_instrumenters'
 graphql (1.13.13) lib/graphql/execution/instrumentation.rb:46:in `block (2 levels) in each_query_call_hooks'
 graphql (1.13.13) lib/graphql/execution/instrumentation.rb:41:in `each_query_call_hooks'
 graphql (1.13.13) lib/graphql/execution/instrumentation.rb:45:in `block in each_query_call_hooks'
 graphql (1.13.13) lib/graphql/execution/instrumentation.rb:72:in `call_hooks'
 graphql (1.13.13) lib/graphql/execution/instrumentation.rb:44:in `each_query_call_hooks'
 graphql (1.13.13) lib/graphql/execution/instrumentation.rb:27:in `block in apply_instrumenters'
 graphql (1.13.13) lib/graphql/execution/instrumentation.rb:72:in `call_hooks'
 graphql (1.13.13) lib/graphql/execution/instrumentation.rb:26:in `apply_instrumenters'
 graphql (1.13.13) lib/graphql/execution/multiplex.rb:190:in `instrument_and_analyze'
 graphql (1.13.13) lib/graphql/execution/multiplex.rb:62:in `block in run_queries'
 graphql (1.13.13) lib/graphql/tracing.rb:67:in `trace'
 graphql (1.13.13) lib/graphql/execution/multiplex.rb:60:in `run_queries'
 graphql (1.13.13) lib/graphql/execution/multiplex.rb:50:in `run_all'
 graphql (1.13.13) lib/graphql/schema.rb:482:in `block in multiplex'
 graphql (1.13.13) lib/graphql/schema.rb:1965:in `with_definition_error_check'
 graphql (1.13.13) lib/graphql/schema.rb:481:in `multiplex'
 graphql (1.13.13) lib/graphql/schema.rb:458:in `execute'
 decidim-api (0.23.6) app/controllers/decidim/api/queries_controller.rb:11:in `create'
 actionpack (5.2.8) lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
 actionpack (5.2.8) lib/abstract_controller/base.rb:194:in `process_action'
 actionpack (5.2.8) lib/action_controller/metal/rendering.rb:30:in `process_action'
 actionpack (5.2.8) lib/abstract_controller/callbacks.rb:42:in `block in process_action'
 activesupport (5.2.8) lib/active_support/callbacks.rb:109:in `block in run_callbacks'
 activesupport (5.2.8) lib/active_support/core_ext/time/zones.rb:66:in `use_zone'
 decidim-core (0.23.6) app/controllers/concerns/decidim/use_organization_time_zone.rb:21:in `use_organization_time_zone'
 activesupport (5.2.8) lib/active_support/callbacks.rb:118:in `block in run_callbacks'
 activesupport (5.2.8) lib/active_support/callbacks.rb:136:in `run_callbacks'
 actionpack (5.2.8) lib/abstract_controller/callbacks.rb:41:in `process_action'
 actionpack (5.2.8) lib/action_controller/metal/rescue.rb:22:in `process_action'
 actionpack (5.2.8) lib/action_controller/metal/instrumentation.rb:34:in `block in process_action'
 activesupport (5.2.8) lib/active_support/notifications.rb:168:in `block in instrument'
 activesupport (5.2.8) lib/active_support/notifications/instrumenter.rb:23:in `instrument'
 activesupport (5.2.8) lib/active_support/notifications.rb:168:in `instrument'
 actionpack (5.2.8) lib/action_controller/metal/instrumentation.rb:32:in `process_action'
 actionpack (5.2.8) lib/action_controller/metal/params_wrapper.rb:256:in `process_action'
 activerecord (5.2.8) lib/active_record/railties/controller_runtime.rb:24:in `process_action'
 actionpack (5.2.8) lib/abstract_controller/base.rb:134:in `process'
 actionview (5.2.8) lib/action_view/rendering.rb:32:in `process'
 actionpack (5.2.8) lib/action_controller/metal.rb:191:in `dispatch'
 actionpack (5.2.8) lib/action_controller/metal.rb:252:in `dispatch'
 actionpack (5.2.8) lib/action_dispatch/routing/route_set.rb:52:in `dispatch'
 actionpack (5.2.8) lib/action_dispatch/routing/route_set.rb:34:in `serve'
 actionpack (5.2.8) lib/action_dispatch/journey/router.rb:52:in `block in serve'
 actionpack (5.2.8) lib/action_dispatch/journey/router.rb:35:in `each'
 actionpack (5.2.8) lib/action_dispatch/journey/router.rb:35:in `serve'
 actionpack (5.2.8) lib/action_dispatch/routing/route_set.rb:840:in `call'
 railties (5.2.8) lib/rails/engine.rb:524:in `call'
 railties (5.2.8) lib/rails/railtie.rb:190:in `public_send'
 railties (5.2.8) lib/rails/railtie.rb:190:in `method_missing'
 actionpack (5.2.8) lib/action_dispatch/routing/mapper.rb:19:in `block in <class:Constraints>'
 actionpack (5.2.8) lib/action_dispatch/routing/mapper.rb:48:in `serve'
 actionpack (5.2.8) lib/action_dispatch/journey/router.rb:52:in `block in serve'
 actionpack (5.2.8) lib/action_dispatch/journey/router.rb:35:in `each'
 actionpack (5.2.8) lib/action_dispatch/journey/router.rb:35:in `serve'
 actionpack (5.2.8) lib/action_dispatch/routing/route_set.rb:840:in `call'
 railties (5.2.8) lib/rails/engine.rb:524:in `call'
 railties (5.2.8) lib/rails/railtie.rb:190:in `public_send'
 railties (5.2.8) lib/rails/railtie.rb:190:in `method_missing'
 actionpack (5.2.8) lib/action_dispatch/routing/mapper.rb:19:in `block in <class:Constraints>'
 actionpack (5.2.8) lib/action_dispatch/routing/mapper.rb:48:in `serve'
 actionpack (5.2.8) lib/action_dispatch/journey/router.rb:52:in `block in serve'
 actionpack (5.2.8) lib/action_dispatch/journey/router.rb:35:in `each'
 actionpack (5.2.8) lib/action_dispatch/journey/router.rb:35:in `serve'
 actionpack (5.2.8) lib/action_dispatch/routing/route_set.rb:840:in `call'
 batch-loader (1.5.0) lib/batch_loader/middleware.rb:11:in `call'
 rack-attack (6.6.1) lib/rack/attack.rb:103:in `call'
 omniauth (1.9.1) lib/omniauth/strategy.rb:192:in `call!'
 omniauth (1.9.1) lib/omniauth/strategy.rb:169:in `call'
 omniauth (1.9.1) lib/omniauth/strategy.rb:192:in `call!'
 omniauth (1.9.1) lib/omniauth/strategy.rb:169:in `call'
 omniauth (1.9.1) lib/omniauth/strategy.rb:192:in `call!'
 omniauth (1.9.1) lib/omniauth/strategy.rb:169:in `call'
 omniauth (1.9.1) lib/omniauth/builder.rb:45:in `call'
 rack-attack (6.6.1) lib/rack/attack.rb:127:in `call'
 warden (1.2.9) lib/warden/manager.rb:36:in `block in call'
 warden (1.2.9) lib/warden/manager.rb:34:in `catch'
 warden (1.2.9) lib/warden/manager.rb:34:in `call'
 decidim-core (0.23.6) app/middleware/decidim/strip_x_forwarded_host.rb:11:in `call'
 decidim-core (0.23.6) app/middleware/decidim/current_organization.rb:21:in `call'
 rack (2.2.3.1) lib/rack/tempfile_reaper.rb:15:in `call'
 rack (2.2.3.1) lib/rack/etag.rb:27:in `call'
 rack (2.2.3.1) lib/rack/conditional_get.rb:40:in `call'
 rack (2.2.3.1) lib/rack/head.rb:12:in `call'
 actionpack (5.2.8) lib/action_dispatch/http/content_security_policy.rb:18:in `call'
 rack (2.2.3.1) lib/rack/session/abstract/id.rb:266:in `context'
 rack (2.2.3.1) lib/rack/session/abstract/id.rb:260:in `call'
 actionpack (5.2.8) lib/action_dispatch/middleware/cookies.rb:670:in `call'
 actionpack (5.2.8) lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
 activesupport (5.2.8) lib/active_support/callbacks.rb:98:in `run_callbacks'
 actionpack (5.2.8) lib/action_dispatch/middleware/callbacks.rb:26:in `call'
 actionpack (5.2.8) lib/action_dispatch/middleware/debug_exceptions.rb:61:in `call'
 actionpack (5.2.8) lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
 railties (5.2.8) lib/rails/rack/logger.rb:38:in `call_app'
 railties (5.2.8) lib/rails/rack/logger.rb:26:in `block in call'
 activesupport (5.2.8) lib/active_support/tagged_logging.rb:71:in `block in tagged'
 activesupport (5.2.8) lib/active_support/tagged_logging.rb:28:in `tagged'
 activesupport (5.2.8) lib/active_support/tagged_logging.rb:71:in `tagged'
 railties (5.2.8) lib/rails/rack/logger.rb:26:in `call'
 actionpack (5.2.8) lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
 request_store (1.5.1) lib/request_store/middleware.rb:19:in `call'
 actionpack (5.2.8) lib/action_dispatch/middleware/request_id.rb:27:in `call'
 rack (2.2.3.1) lib/rack/method_override.rb:24:in `call'
 activesupport (5.2.8) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
 actionpack (5.2.8) lib/action_dispatch/middleware/executor.rb:14:in `call'
 rack (2.2.3.1) lib/rack/sendfile.rb:110:in `call'
 actionpack (5.2.8) lib/action_dispatch/middleware/ssl.rb:74:in `call'
 rack-cors (1.1.1) lib/rack/cors.rb:100:in `call'
 railties (5.2.8) lib/rails/engine.rb:524:in `call'
 /usr/lib/ruby/vendor_ruby/phusion_passenger/rack/thread_handler_extension.rb:107:in `process_request'
 /usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler/thread_handler.rb:157:in `accept_and_process_next_request'
 /usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler/thread_handler.rb:110:in `main_loop'
 /usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler.rb:419:in `block (3 levels) in start_threads'
 /usr/lib/ruby/vendor_ruby/phusion_passenger/utils.rb:113:in `block in create_thread_and_abort_on_exception'
 Processing by Decidim::ErrorsController#internal_server_error as */*

```

The reason why, was because graphql was tied to version 1.13 while it should have been 1.12. I pinned graphql version to the correct one and sorted the issue.

This commit includes removing references to memcached. This is temporary as we evaluate how necessary a cache server will be after upgrading