### PR TITLE
Removing the hability to invite users

### DIFF
--- a/app/views/layouts/decidim/_user_menu.html.erb
+++ b/app/views/layouts/decidim/_user_menu.html.erb
@@ -4,7 +4,6 @@
 <% end %>
 <li><%= link_to t(".notifications"), decidim.notifications_path %></li>
 <li><%= link_to t(".conversations"), decidim.conversations_path %></li>
-<li><%= link_to t(".invite_friends"), main_app.user_invitations_path %></li>
 <% if allowed_to? :read, :admin_dashboard %>
   <li><%= link_to t(".admin_dashboard"), decidim_admin.root_path %></li>
 <% end %>

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -45,9 +45,9 @@ Rails.application.config.i18n.available_locales = Decidim.available_locales
 Rails.application.config.i18n.default_locale = Decidim.default_locale
 
 # add the invitations menu item to the user profile
-Decidim.menu :user_menu do |menu|
-  menu.item t("invitations", scope: "layouts.decidim.user_profile"), main_app.user_invitations_path, position: 2, active: :inclusive
-end
+# Decidim.menu :user_menu do |menu|
+#   menu.item t("invitations", scope: "layouts.decidim.user_profile"), main_app.user_invitations_path, position: 2, active: :inclusive
+# end
 
 Decidim::Verifications.register_workflow(:anybody_authorization_handler) do |workflow|
   workflow.form = "AnybodyAuthorizationHandler"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,12 @@
 Rails.application.routes.draw do
+  # TODO: Remove this feature once defined
+  # resources :user_invitations, controller: :invitations,
+  #   only: %i(index new create destroy ) do
 
-  resources :user_invitations, controller: :invitations,
-    only: %i(index new create destroy ) do
-
-    member do
-      patch :resend
-    end
-  end
+  #   member do
+  #     patch :resend
+  #   end
+  # end
 
   if Rails.env.development?
    mount LetterOpenerWeb::Engine, at: "/letter_opener"


### PR DESCRIPTION
At the requirement of the FundAction team I am removing the ability to send invitations while keeping the authorization handler so that we allow the fundaction team to use the impersonations feature. This is not a total removal in case they want them back.