### PR TITLE
Fixes blocked users receiving newsletter

### DIFF
--- a/app/patches/newsletter_recipients_patch.rb
+++ b/app/patches/newsletter_recipients_patch.rb
@@ -1,0 +1,34 @@
+module NewsletterRecipientsPatch
+  def self.apply
+    Decidim::Admin::NewsletterRecipients.prepend self unless Decidim::Admin::NewsletterRecipients < self
+  end
+
+  def query
+    recipients = recipients_base_query
+
+    recipients = recipients.interested_in_scopes(@form.scope_ids) if @form.scope_ids.present?
+
+    followers = recipients.where(id: user_id_of_followers) if @form.send_to_followers
+
+    participants = recipients.where(id: participant_ids) if @form.send_to_participants
+
+    recipients = participants if @form.send_to_participants
+    recipients = followers if @form.send_to_followers
+    recipients = (followers + participants).uniq if @form.send_to_followers && @form.send_to_participants
+
+    recipients
+  end
+
+  private
+
+  def recipients_base_query
+    Decidim::User.where(
+                  organization: @form.current_organization,
+                 deleted_at: nil, 
+                 blocked: false, 
+                 managed: false)
+                 .where.not(newsletter_notifications_at: nil)
+                 .where.not(email: nil)
+                 .confirmed
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,7 @@ module FundAction
       UpdateAccountPatch.apply
       UserPatch.apply
       UserPresenterPatch.apply
+      NewsletterRecipientsPatch.apply
     end
 
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
Admin reported blocked users are still receiving newsletters.

From this https://github.com/decidim/decidim/pull/13689/files I created a temporary patch until we migrate to newer versions